### PR TITLE
oh-my-posh

### DIFF
--- a/pkgs/tools/misc/oh-my-posh/default.nix
+++ b/pkgs/tools/misc/oh-my-posh/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, fetchFromGitHub
+, buildGoModule
+, getThemes ? false
+}:
+
+buildGoModule rec {
+  version = "7.85.2";
+  pname = "oh-my-posh";
+  owner = "JanDeDobbeleer";
+
+  src = fetchFromGitHub
+    {
+      inherit owner;
+      repo = pname;
+      rev = "v${version}";
+      sha256 = "OAS0Uehgy4UFkhe+C7TbFTTBJkAS3G4g8ruyS90DqOQ=";
+    };
+  modRoot = "./src";
+  vendorSha256 = "trG+w+xUlfsBkMfkM7vRxO41vXdymPFp5IYILR7hlQc=";
+
+  ldflags = [ "-a" "-s" "-w" "-X" "main.Version=${version}" "-extldflags" ''"-static"'' ];
+
+  tags = [ "netgo" "osusergo" "static_build" ];
+
+  dontFixup = true;
+
+  meta = with lib; {
+    license = licenses.mit;
+    homepage = "https://ohmyposh.dev/";
+    description = "A prompt theme engine for any shell";
+    maintainers = with maintainers; [ shrykewindgrace ];
+  };
+
+  postInstall = lib.optionalString getThemes ''
+    mkdir -p $out
+    cp -r ${src}/themes $out
+  '';
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8897,6 +8897,8 @@ with pkgs;
 
   ogdf = callPackage ../development/libraries/ogdf { };
 
+  oh-my-posh = callPackage ../tools/misc/oh-my-posh { };
+
   oh-my-zsh = callPackage ../shells/zsh/oh-my-zsh { };
 
   ola = callPackage ../applications/misc/ola { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
